### PR TITLE
Fix invalid command GUI

### DIFF
--- a/src/main/java/coydir/commons/core/Messages.java
+++ b/src/main/java/coydir/commons/core/Messages.java
@@ -5,7 +5,7 @@ package coydir.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "is an Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";

--- a/src/main/java/coydir/logic/parser/AddressBookParser.java
+++ b/src/main/java/coydir/logic/parser/AddressBookParser.java
@@ -69,7 +69,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         default:
-            throw new ParseException('"'+ commandWord + '"' + MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException('"' + commandWord + '"' + MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/coydir/logic/parser/AddressBookParser.java
+++ b/src/main/java/coydir/logic/parser/AddressBookParser.java
@@ -69,7 +69,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException('"'+ commandWord + '"' + MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/coydir/ui/CommandBox.java
+++ b/src/main/java/coydir/ui/CommandBox.java
@@ -46,6 +46,7 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+            commandTextField.setText("");
         }
     }
 

--- a/src/test/java/coydir/logic/LogicManagerTest.java
+++ b/src/test/java/coydir/logic/LogicManagerTest.java
@@ -54,7 +54,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, '"'+ invalidCommand + '"' + MESSAGE_UNKNOWN_COMMAND);
     }
 
     @Test

--- a/src/test/java/coydir/logic/LogicManagerTest.java
+++ b/src/test/java/coydir/logic/LogicManagerTest.java
@@ -54,7 +54,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, '"'+ invalidCommand + '"' + MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, '"' + invalidCommand + '"' + MESSAGE_UNKNOWN_COMMAND);
     }
 
     @Test

--- a/src/test/java/coydir/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/coydir/logic/commands/DeleteCommandTest.java
@@ -67,7 +67,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        
+
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(2 < model.getAddressBook().getPersonList().size());
 

--- a/src/test/java/coydir/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/coydir/logic/commands/DeleteCommandTest.java
@@ -67,7 +67,6 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
         
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(2 < model.getAddressBook().getPersonList().size());

--- a/src/test/java/coydir/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/coydir/logic/parser/AddressBookParserTest.java
@@ -97,6 +97,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        String userinput = "unknownCommand";
+        assertThrows(ParseException.class, '"'+ userinput + '"' + MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/coydir/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/coydir/logic/parser/AddressBookParserTest.java
@@ -99,6 +99,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         String userinput = "unknownCommand";
-        assertThrows(ParseException.class, '"'+ userinput + '"' + MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, '"' + userinput + '"' + MESSAGE_UNKNOWN_COMMAND,
+                () -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/coydir/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/coydir/logic/parser/AddressBookParserTest.java
@@ -99,7 +99,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         String userinput = "unknownCommand";
-        assertThrows(ParseException.class, '"' + userinput + '"' + MESSAGE_UNKNOWN_COMMAND,
-                () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, '"' + userinput + '"' + MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/coydir/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/coydir/logic/parser/DeleteCommandParserTest.java
@@ -4,6 +4,7 @@ import static coydir.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static coydir.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static coydir.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static coydir.testutil.TypicalIndexes.ID_FIRST_EMPLOYEE;
+
 import org.junit.jupiter.api.Test;
 
 import coydir.logic.commands.DeleteCommand;


### PR DESCRIPTION
Fixed the invalid command GUI. Now when User types in a invalid command, it is cleared and it outputs the command and indicates that it is invalid command