### PR TITLE
Implements `view` command and the ability to display more detailed information 

### DIFF
--- a/src/main/java/coydir/logic/commands/CommandResult.java
+++ b/src/main/java/coydir/logic/commands/CommandResult.java
@@ -17,6 +17,7 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -45,6 +46,7 @@ public class CommandResult {
     public boolean isExit() {
         return exit;
     }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/coydir/logic/commands/CommandResult.java
+++ b/src/main/java/coydir/logic/commands/CommandResult.java
@@ -17,6 +17,10 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    private final boolean view;
+
+    private int viewIndex;
+
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -25,6 +29,18 @@ public class CommandResult {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.view = false;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields.
+     */
+    public CommandResult(String feedbackToUser, boolean view, int index) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = false;
+        this.exit = false;
+        this.view = view;
+        this.viewIndex = index;
     }
 
     /**
@@ -45,6 +61,14 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isView() {
+        return view;
+    }
+
+    public int getViewIndex() {
+        return viewIndex;
     }
 
 

--- a/src/main/java/coydir/logic/commands/ViewCommand.java
+++ b/src/main/java/coydir/logic/commands/ViewCommand.java
@@ -1,0 +1,45 @@
+package coydir.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import coydir.commons.core.Messages;
+import coydir.commons.core.index.Index;
+import coydir.logic.commands.exceptions.CommandException;
+import coydir.model.Model;
+import coydir.model.person.Person;
+
+/**
+ * view a person's particular identified using it's displayed index from the address book.
+ */
+public class ViewCommand extends Command {
+    public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": View the person identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Viewing Person's particulars: %1$s";
+
+    private final Index index;
+
+    public ViewCommand(Index index) {
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        Person personToView;
+        try {
+            personToView = lastShownList.get(index.getZeroBased());
+
+            return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, personToView.getName()));
+        } catch (IndexOutOfBoundsException e) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+    }
+}

--- a/src/main/java/coydir/logic/commands/ViewCommand.java
+++ b/src/main/java/coydir/logic/commands/ViewCommand.java
@@ -36,8 +36,8 @@ public class ViewCommand extends Command {
         Person personToView;
         try {
             personToView = lastShownList.get(index.getZeroBased());
-
-            return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, personToView.getName()));
+            return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, personToView.getName()),
+                    true, index.getZeroBased());
         } catch (IndexOutOfBoundsException e) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }

--- a/src/main/java/coydir/logic/parser/AddressBookParser.java
+++ b/src/main/java/coydir/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import coydir.logic.commands.ExitCommand;
 import coydir.logic.commands.FindCommand;
 import coydir.logic.commands.HelpCommand;
 import coydir.logic.commands.ListCommand;
+import coydir.logic.commands.ViewCommand;
 import coydir.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException('"' + commandWord + '"' + MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/coydir/logic/parser/ViewCommandParser.java
+++ b/src/main/java/coydir/logic/parser/ViewCommandParser.java
@@ -1,0 +1,29 @@
+package coydir.logic.parser;
+
+import static coydir.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import coydir.commons.core.index.Index;
+import coydir.logic.commands.ViewCommand;
+import coydir.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ViewCommand object
+ */
+public class ViewCommandParser implements Parser<ViewCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ViewCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ViewCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/coydir/model/person/UniquePersonList.java
+++ b/src/main/java/coydir/model/person/UniquePersonList.java
@@ -97,6 +97,10 @@ public class UniquePersonList implements Iterable<Person> {
         internalList.setAll(persons);
     }
 
+    public Person getPersons(int index) {
+        return internalList.get(index);
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/main/java/coydir/ui/MainWindow.java
+++ b/src/main/java/coydir/ui/MainWindow.java
@@ -35,6 +35,8 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    private PersonInfo personInfo;
+
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -49,6 +51,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane statusbarPlaceholder;
+
+    @FXML
+    private StackPane personInfoPanelPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -112,6 +117,9 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        personInfo = new PersonInfo(logic.getFilteredPersonList().get(0));
+        personInfoPanelPlaceholder.getChildren().add(personInfo.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/coydir/ui/MainWindow.java
+++ b/src/main/java/coydir/ui/MainWindow.java
@@ -195,6 +195,12 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    private void handleView(int index) {
+        personInfo.update(logic.getFilteredPersonList().get(index));
+        personInfoPanelPlaceholder.getChildren().removeAll();
+        personInfoPanelPlaceholder.getChildren().set(0, personInfo.getRoot());
+    }
+
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
     }
@@ -216,6 +222,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            if (commandResult.isView()) {
+                handleView(commandResult.getViewIndex());
             }
 
             return commandResult;

--- a/src/main/java/coydir/ui/PersonCard.java
+++ b/src/main/java/coydir/ui/PersonCard.java
@@ -55,9 +55,9 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         employeeId.setText("Employee ID:  " + String.format("%6s", person.getEmployeeId().value).replace(' ', '0'));
         position.setText("Position:  " + person.getPosition().value);
-        phone.setText("Phone number:  " + person.getPhone().value);
-        address.setText("Address:  " + person.getAddress().value);
-        email.setText("Email address:  " + person.getEmail().value);
+        //phone.setText("Phone number:  " + person.getPhone().value);
+        //address.setText("Address:  " + person.getAddress().value);
+        //email.setText("Email address:  " + person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/coydir/ui/PersonCard.java
+++ b/src/main/java/coydir/ui/PersonCard.java
@@ -55,9 +55,6 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         employeeId.setText("Employee ID:  " + String.format("%6s", person.getEmployeeId().value).replace(' ', '0'));
         position.setText("Position:  " + person.getPosition().value);
-        //phone.setText("Phone number:  " + person.getPhone().value);
-        //address.setText("Address:  " + person.getAddress().value);
-        //email.setText("Email address:  " + person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/coydir/ui/PersonInfo.java
+++ b/src/main/java/coydir/ui/PersonInfo.java
@@ -1,0 +1,67 @@
+package coydir.ui;
+
+import java.util.Comparator;
+
+import coydir.model.person.Person;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * An UI component that displays detailed information of a {@code Person}.
+ */
+public class PersonInfo extends UiPart<Region> {
+    private static final String FXML = "PersonInfo.fxml";
+
+    private Person person;
+
+    @FXML
+    private HBox personInfo;
+    @FXML
+    private Label name;
+    @FXML
+    private Label employeeId;
+    @FXML
+    private Label position;
+    @FXML
+    private Label phone;
+    @FXML
+    private Label address;
+    @FXML
+    private Label email;
+    @FXML
+    private FlowPane tags;
+
+    /**
+     * Creates a {@code PersonInfo} to display the {@code Person} particulars.
+     */
+    public PersonInfo(Person person) {
+        super(FXML);
+        this.person = person;
+        name.setText(this.person.getName().fullName);
+        employeeId.setText("Employee ID:  " + String.format(
+                "%6s", this.person.getEmployeeId().value).replace(' ', '0'));
+        position.setText("Position:  " + this.person.getPosition().value);
+        phone.setText("Phone number:  " + this.person.getPhone().value);
+        address.setText("Address:  " + this.person.getAddress().value);
+        email.setText("Email address:  " + this.person.getEmail().value);
+        this.person.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    /*public void update(Person person) {
+        this.person = person;
+        name.setText(person.getName().fullName);
+        employeeId.setText("Employee ID:  " + String.format("%6s", person.getEmployeeId().value).replace(' ', '0'));
+        position.setText("Position:  " + person.getPosition().value);
+        phone.setText("Phone number:  " + person.getPhone().value);
+        address.setText("Address:  " + person.getAddress().value);
+        email.setText("Email address:  " + person.getEmail().value);
+        person.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }*/
+}

--- a/src/main/java/coydir/ui/PersonInfo.java
+++ b/src/main/java/coydir/ui/PersonInfo.java
@@ -39,17 +39,7 @@ public class PersonInfo extends UiPart<Region> {
      */
     public PersonInfo(Person person) {
         super(FXML);
-        this.person = person;
-        name.setText(this.person.getName().fullName);
-        employeeId.setText("Employee ID:  " + String.format(
-                "%6s", this.person.getEmployeeId().value).replace(' ', '0'));
-        position.setText("Position:  " + this.person.getPosition().value);
-        phone.setText("Phone number:  " + this.person.getPhone().value);
-        address.setText("Address:  " + this.person.getAddress().value);
-        email.setText("Email address:  " + this.person.getEmail().value);
-        this.person.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        update(person);
     }
 
     /**
@@ -64,6 +54,7 @@ public class PersonInfo extends UiPart<Region> {
         phone.setText("Phone number:  " + person.getPhone().value);
         address.setText("Address:  " + person.getAddress().value);
         email.setText("Email address:  " + person.getEmail().value);
+        tags.getChildren().clear();
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/coydir/ui/PersonInfo.java
+++ b/src/main/java/coydir/ui/PersonInfo.java
@@ -52,7 +52,11 @@ public class PersonInfo extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 
-    /*public void update(Person person) {
+    /**
+     * Update the person particulars in the {@code PersonInfo} panel.
+     * @param person
+     */
+    public void update(Person person) {
         this.person = person;
         name.setText(person.getName().fullName);
         employeeId.setText("Employee ID:  " + String.format("%6s", person.getEmployeeId().value).replace(' ', '0'));
@@ -63,5 +67,5 @@ public class PersonInfo extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-    }*/
+    }
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,6 +11,10 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.control.TextArea?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Coydir" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -37,12 +41,21 @@
           </Menu>
         </MenuBar>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+        <HBox fx:id="employeeList" VBox.vgrow="ALWAYS">
+          <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10" />
+            </padding>
+            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+
+          <VBox fx:id="personInfo" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets top="5" right="10" bottom="5" left="10" />
+            </padding>
+            <StackPane fx:id="personInfoPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+        </HBox>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
                    minHeight="100" prefHeight="100" maxHeight="100">

--- a/src/main/resources/view/PersonInfo.fxml
+++ b/src/main/resources/view/PersonInfo.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.geometry.Insets?>
+<HBox fx:id="personInfo" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" prefHeight="400.0" prefWidth="600.0">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="80" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+            <FlowPane fx:id="tags" />
+            <Label fx:id="employeeId" styleClass="cell_small_label" text="\$employeeId" />
+            <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
+            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,9 +30,6 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="employeeId" styleClass="cell_small_label" text="\$employeeId" />
       <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
-<!--      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />-->
-<!--      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />-->
-<!--      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />-->
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="80" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
@@ -30,9 +30,9 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="employeeId" styleClass="cell_small_label" text="\$employeeId" />
       <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+<!--      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />-->
+<!--      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />-->
+<!--      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />-->
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Resolves #76 #77 

As shown in the images below, the more detailed person particulars are hidden from user at the beginning.
If required, user can use the `view` command to see the all the details of the employee.

![image](https://user-images.githubusercontent.com/37807290/195194205-bccad398-ae43-470b-8546-0ada6befc8e1.png)
![image](https://user-images.githubusercontent.com/37807290/195194324-b51fa97c-6449-4f60-9c10-02926268d1fd.png)

### Things to note:
- The `view` command search for user based on the index value that user key in
- Only employees that are visible in the left panel will be in the searching list (good for future `filter` command)

### Future enhancements:
- Implement clickable `personCard` so that user can view the person particulars by clicking on the card
- Change the color of the font on the right panel
- Further enhance the aesthetic of the UI
- Fix right panel can be covered when user resize the window
