### PR TITLE
Update help command

### DIFF
--- a/src/main/java/coydir/MainApp.java
+++ b/src/main/java/coydir/MainApp.java
@@ -29,7 +29,6 @@ import coydir.storage.UserPrefsStorage;
 import coydir.ui.Ui;
 import coydir.ui.UiManager;
 import javafx.application.Application;
-import javafx.application.HostServices;
 import javafx.stage.Stage;
 
 /**
@@ -37,7 +36,7 @@ import javafx.stage.Stage;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 3, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -46,7 +45,6 @@ public class MainApp extends Application {
     protected Storage storage;
     protected Model model;
     protected Config config;
-    protected HostServices hostService;
 
     @Override
     public void init() throws Exception {
@@ -68,8 +66,6 @@ public class MainApp extends Application {
         logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);
-
-        hostService = getHostServices();
     }
 
     /**
@@ -167,10 +163,6 @@ public class MainApp extends Application {
         }
 
         return initializedPrefs;
-    }
-
-    public void openWebsite(String url) {
-        hostService.showDocument(url);
     }
 
     @Override

--- a/src/main/java/coydir/MainApp.java
+++ b/src/main/java/coydir/MainApp.java
@@ -29,6 +29,7 @@ import coydir.storage.UserPrefsStorage;
 import coydir.ui.Ui;
 import coydir.ui.UiManager;
 import javafx.application.Application;
+import javafx.application.HostServices;
 import javafx.stage.Stage;
 
 /**
@@ -45,6 +46,7 @@ public class MainApp extends Application {
     protected Storage storage;
     protected Model model;
     protected Config config;
+    protected HostServices hostService;
 
     @Override
     public void init() throws Exception {
@@ -66,6 +68,8 @@ public class MainApp extends Application {
         logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);
+
+        hostService = getHostServices();
     }
 
     /**
@@ -163,6 +167,10 @@ public class MainApp extends Application {
         }
 
         return initializedPrefs;
+    }
+
+    public void openWebsite(String url) {
+        hostService.showDocument(url);
     }
 
     @Override

--- a/src/main/java/coydir/ui/CommandFormat.java
+++ b/src/main/java/coydir/ui/CommandFormat.java
@@ -9,9 +9,6 @@ import javafx.collections.ObservableList;
  * Used in {@code HelpWindow} for the help command.
  */
 public class CommandFormat {
-    private SimpleStringProperty command;
-    private SimpleStringProperty usage;
-
     // All basic commands below
     private static final CommandFormat ADD_COMMAND_FORMAT = new CommandFormat(
             "add",
@@ -38,7 +35,10 @@ public class CommandFormat {
             "Exits the program.",
             "exit");
 
-    // All advanced commands below
+    // All advanced commands below (currently none)
+
+    private SimpleStringProperty command;
+    private SimpleStringProperty usage;
 
     /**
      * Creates a {@code CommandFormat} object with a specified command and corresponding description, format.

--- a/src/main/java/coydir/ui/CommandFormat.java
+++ b/src/main/java/coydir/ui/CommandFormat.java
@@ -1,5 +1,7 @@
 package coydir.ui;
 
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 /**
@@ -7,9 +9,8 @@ import javafx.collections.ObservableList;
  * Used in {@code HelpWindow} for the help command.
  */
 public class CommandFormat {
-    private String command;
-    private String description;
-    private String format;
+    private SimpleStringProperty command;
+    private SimpleStringProperty usage;
 
     // All basic commands below
     private static final CommandFormat ADD_COMMAND_FORMAT = new CommandFormat(
@@ -47,9 +48,8 @@ public class CommandFormat {
      * @param format The corresponding format.
      */
     public CommandFormat(String command, String description, String format) {
-        this.command = command;
-        this.description = description;
-        this.format = format;
+        this.command = new SimpleStringProperty(command);
+        this.usage = new SimpleStringProperty(String.format("%s\nFormat: %s", description, format));
     }
 
     public static ObservableList<CommandFormat> getBasicCommands() {
@@ -69,10 +69,10 @@ public class CommandFormat {
     }
 
     public String getCommand() {
-        return this.command;
+        return this.command.get();
     }
 
-    public String getFormat() {
-        return this.format;
+    public String getUsage() {
+        return this.usage.get();
     }
 }

--- a/src/main/java/coydir/ui/CommandFormat.java
+++ b/src/main/java/coydir/ui/CommandFormat.java
@@ -1,0 +1,78 @@
+package coydir.ui;
+
+import javafx.collections.ObservableList;
+
+/**
+ * Format and usage for a Coydir command.
+ * Used in {@code HelpWindow} for the help command.
+ */
+public class CommandFormat {
+    private String command;
+    private String description;
+    private String format;
+
+    // All basic commands below
+    private static final CommandFormat ADD_COMMAND_FORMAT = new CommandFormat(
+            "add",
+            "Adds a person to Coydir.",
+            "add n/NAME j/POSITION [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]");
+
+    private static final CommandFormat LIST_COMMAND_FORMAT = new CommandFormat(
+            "list",
+            "Shows a list of all persons in the company.",
+            "list");
+
+    private static final CommandFormat VIEW_COMMAND_FORMAT = new CommandFormat(
+            "view",
+            "View the details of an existing person in Coydir.",
+            "view INDEX");
+
+    private static final CommandFormat DELETE_COMMAND_FORMAT = new CommandFormat(
+            "delete",
+            "Deletes the specified person from Coydir, given the Employee ID.",
+            "delete EMPLOYEE_ID");
+
+    private static final CommandFormat EXIT_COMMAND_FORMAT = new CommandFormat(
+            "exit",
+            "Exits the program.",
+            "exit");
+
+    // All advanced commands below
+
+    /**
+     * Creates a {@code CommandFormat} object with a specified command and corresponding description, format.
+     *
+     * @param command The specified command.
+     * @param description The corresponding description.
+     * @param format The corresponding format.
+     */
+    public CommandFormat(String command, String description, String format) {
+        this.command = command;
+        this.description = description;
+        this.format = format;
+    }
+
+    public static ObservableList<CommandFormat> getBasicCommands() {
+        return FXCollections.observableArrayList(
+                ADD_COMMAND_FORMAT,
+                LIST_COMMAND_FORMAT,
+                VIEW_COMMAND_FORMAT,
+                DELETE_COMMAND_FORMAT,
+                EXIT_COMMAND_FORMAT
+                );
+    }
+
+    // Currently no advanced commands implemented
+    // **As of v1.2**
+    public static ObservableList<CommandFormat> getAdvancedCommands() {
+        return FXCollections.observableArrayList();
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public String getFormat() {
+        return this.format;
+    }
+}

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -28,8 +28,8 @@ public class HelpWindow extends UiPart<Stage> {
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
-    private static final int ROW_HEIGHT = 30;
-    private static final int SAFETY_MARGIN = 35;
+    private static final int ROW_HEIGHT = 40; // Used to bind cell height
+    private static final int HEADER_HEIGHT = 45; // Accurate for current label content
 
     private static Application hostServicesApp = new Application() {
             @Override
@@ -113,16 +113,19 @@ public class HelpWindow extends UiPart<Stage> {
 
     private void initAllTableViews() {
         this.initTableView(this.basicTableView, CommandFormat.getBasicCommands());
-        this.initTableView(this.advancedTableView, CommandFormat.getAdvancedCommands());
+        // this.initTableView(this.advancedTableView, CommandFormat.getAdvancedCommands());
     }
 
     private void initTableView(TableView<CommandFormat> tableView, ObservableList<CommandFormat> commands) {
         tableView.setSelectionModel(null);
         tableView.setItems(commands);
+        tableView.setFixedCellSize(ROW_HEIGHT);
         tableView.prefHeightProperty().bind(
                 Bindings.size(tableView.getItems())
                 .multiply(ROW_HEIGHT)
-                .add(SAFETY_MARGIN));
+                .add(HEADER_HEIGHT));
+        tableView.minHeightProperty().bind(tableView.prefHeightProperty());
+        tableView.maxHeightProperty().bind(tableView.prefHeightProperty());
 
         TableColumn<CommandFormat, String> commandCol = new TableColumn<>("Command");
         commandCol.setCellValueFactory(new PropertyValueFactory<>("command"));

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -8,6 +8,7 @@ import javafx.application.HostServices;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TableView;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
@@ -29,10 +30,16 @@ public class HelpWindow extends UiPart<Stage> {
         };
 
     @FXML
-    private Button copyButton;
+    private Button openButton;
 
     @FXML
     private Label helpMessage;
+
+    @FXML
+    private TableView basicTableView;
+
+    @FXML
+    private TableView advancedTableView;
 
     /**
      * Creates a new HelpWindow.
@@ -94,17 +101,6 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void focus() {
         getRoot().requestFocus();
-    }
-
-    /**
-     * Copies the URL to the user guide to the clipboard.
-     */
-    @FXML
-    private void copyUrl() {
-        final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent url = new ClipboardContent();
-        url.putString(USERGUIDE_URL);
-        clipboard.setContent(url);
     }
 
     /**

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -49,6 +49,7 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
+        this.initAllTableViews();
     }
 
     /**
@@ -101,6 +102,15 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void focus() {
         getRoot().requestFocus();
+    }
+
+    private void initAllTableViews() {
+        this.initTableView(this.basicTableView, CommandFormat.getBasicCommands());
+        this.initTableView(this.advancedTableView, CommandFormat.getAdvancedCommands());
+    }
+
+    private void initTableView(TableView<Command> tableView, ObservableList<CommandFormat> commands) {
+
     }
 
     /**

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -5,10 +5,14 @@ import java.util.logging.Logger;
 import coydir.commons.core.LogsCenter;
 import javafx.application.Application;
 import javafx.application.HostServices;
+import javafx.beans.binding.Bindings;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
@@ -23,6 +27,9 @@ public class HelpWindow extends UiPart<Stage> {
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
+
+    private static final int ROW_HEIGHT = 30;
+    private static final int SAFETY_MARGIN = 35;
 
     private static Application hostServicesApp = new Application() {
             @Override
@@ -109,8 +116,31 @@ public class HelpWindow extends UiPart<Stage> {
         this.initTableView(this.advancedTableView, CommandFormat.getAdvancedCommands());
     }
 
-    private void initTableView(TableView<Command> tableView, ObservableList<CommandFormat> commands) {
+    private void initTableView(TableView<CommandFormat> tableView, ObservableList<CommandFormat> commands) {
+        tableView.setSelectionModel(null);
+        tableView.setItems(commands);
+        tableView.prefHeightProperty().bind(
+                Bindings.size(tableView.getItems())
+                .multiply(ROW_HEIGHT)
+                .add(SAFETY_MARGIN));
 
+        TableColumn<CommandFormat, String> commandCol = new TableColumn<>("Command");
+        commandCol.setCellValueFactory(new PropertyValueFactory<>("command"));
+        commandCol.setSortable(false);
+        commandCol.setResizable(false);
+        commandCol.setReorderable(false);
+
+        TableColumn<CommandFormat, String> usageCol = new TableColumn<>("Usage");
+        usageCol.setCellValueFactory(new PropertyValueFactory<>("usage"));
+        usageCol.setSortable(false);
+        usageCol.setResizable(false);
+        usageCol.setReorderable(false);
+
+        commandCol.prefWidthProperty().bind(tableView.widthProperty().multiply(0.13));
+        usageCol.prefWidthProperty().bind(tableView.widthProperty().multiply(0.85));
+
+        tableView.getColumns().add(commandCol);
+        tableView.getColumns().add(usageCol);
     }
 
     /**

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -4,7 +4,6 @@ import java.util.logging.Logger;
 
 import coydir.commons.core.LogsCenter;
 import javafx.application.Application;
-import javafx.application.HostServices;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -13,8 +12,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 
 /**

--- a/src/main/java/coydir/ui/HelpWindow.java
+++ b/src/main/java/coydir/ui/HelpWindow.java
@@ -3,6 +3,8 @@ package coydir.ui;
 import java.util.logging.Logger;
 
 import coydir.commons.core.LogsCenter;
+import javafx.application.Application;
+import javafx.application.HostServices;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -16,10 +18,15 @@ import javafx.stage.Stage;
 public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2223s1-cs2103t-t15-1.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Click for more details: ";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
+
+    private static Application hostServicesApp = new Application() {
+            @Override
+            public void start(Stage stage) {}
+        };
 
     @FXML
     private Button copyButton;
@@ -98,5 +105,13 @@ public class HelpWindow extends UiPart<Stage> {
         final ClipboardContent url = new ClipboardContent();
         url.putString(USERGUIDE_URL);
         clipboard.setContent(url);
+    }
+
+    /**
+     * Opens the URL to the user guide in the default browser.
+     */
+    @FXML
+    private void openWebsite() {
+        HelpWindow.hostServicesApp.getHostServices().showDocument(USERGUIDE_URL);
     }
 }

--- a/src/main/java/coydir/ui/UiManager.java
+++ b/src/main/java/coydir/ui/UiManager.java
@@ -4,6 +4,7 @@ import java.util.logging.Logger;
 
 import coydir.MainApp;
 import coydir.commons.core.LogsCenter;
+import coydir.commons.util.AppUtil;
 import coydir.commons.util.StringUtil;
 import coydir.logic.Logic;
 import javafx.application.Platform;
@@ -37,7 +38,7 @@ public class UiManager implements Ui {
         logger.info("Starting UI...");
 
         //Set the application icon.
-        primaryStage.getIcons().add(getImage(ICON_APPLICATION));
+        primaryStage.getIcons().add(AppUtil.getImage(ICON_APPLICATION));
 
         try {
             mainWindow = new MainWindow(primaryStage, logic);
@@ -48,10 +49,6 @@ public class UiManager implements Ui {
             logger.severe(StringUtil.getDetails(e));
             showFatalErrorDialogAndShutdown("Fatal error during initializing", e);
         }
-    }
-
-    private Image getImage(String imagePath) {
-        return new Image(MainApp.class.getResourceAsStream(imagePath));
     }
 
     void showAlertDialogAndWait(Alert.AlertType type, String title, String headerText, String contentText) {

--- a/src/main/java/coydir/ui/UiManager.java
+++ b/src/main/java/coydir/ui/UiManager.java
@@ -2,7 +2,6 @@ package coydir.ui;
 
 import java.util.logging.Logger;
 
-import coydir.MainApp;
 import coydir.commons.core.LogsCenter;
 import coydir.commons.util.AppUtil;
 import coydir.commons.util.StringUtil;
@@ -10,7 +9,6 @@ import coydir.logic.Logic;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 /**

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,19 +1,20 @@
-#copyButton, #helpMessage {
-    -fx-text-fill: white;
+#copyButton,
+#helpMessage {
+  -fx-text-fill: white;
 }
 
 #copyButton {
-    -fx-background-color: dimgray;
+  -fx-background-color: dimgray;
 }
 
 #copyButton:hover {
-    -fx-background-color: gray;
+  -fx-background-color: gray;
 }
 
 #copyButton:armed {
-    -fx-background-color: darkgray;
+  -fx-background-color: darkgray;
 }
 
-#helpMessageContainer {
-    -fx-background-color: derive(#1d1d1d, 20%);
+#helpContainer {
+  -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,10 +1,53 @@
+.commands-panel {
+  -fx-background-color: derive(#1d1d1d, 20%);
+}
+
 .help-label {
-  -fx-font-size: 32pt;
-  -fx-font-family: "SF Mono Light";
+  -fx-padding: 2 6 2 6px;
+  -fx-font-size: 16pt;
   -fx-text-fill: white;
   -fx-opacity: 1;
-  -fs-background-color: derive(#1d1d1d, 20%);
-  background-color: #383838; /* Used in the default.html file */
+}
+
+.table-view {
+  -fx-background-color: derive(#1d1d1d, 20%);
+}
+
+.table-view .column-header {
+  -fx-background-color: derive(#373737, 20%);
+}
+
+.table-view .column-header-background {
+  -fx-background-color: derive(#373737, 20%);
+}
+
+.table-view .column-header-background .label {
+  -fx-background-color: transparent;
+  -fx-font-size: 11pt;
+  -fx-font-weight: bold;
+  -fx-text-fill: white;
+  -fx-opacity: 1;
+  -fx-padding: 2 0 2 2px;
+}
+
+.table-view .table-cell {
+  -fx-padding: 2 4 2 4px;
+  -fx-font-size: 10pt;
+  -fx-text-fill: white;
+  -fx-opacity: 1;
+}
+
+.table-row-cell {
+  -fx-background-color: dimgray;
+  -fx-background-insets: 0, 1 0 1 0;
+}
+
+.table-row-cell: hover {
+  -fx-background-color: gray;
+}
+
+#helpContainer {
+  -fx-background-color: derive(#1d1d1d, 20%);
 }
 
 #openButton,
@@ -22,8 +65,4 @@
 
 #openButton:armed {
   -fx-background-color: darkgray;
-}
-
-#helpContainer {
-  -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,3 +1,12 @@
+.help-label {
+  -fx-font-size: 32pt;
+  -fx-font-family: "SF Mono Light";
+  -fx-text-fill: white;
+  -fx-opacity: 1;
+  -fs-background-color: derive(#1d1d1d, 20%);
+  background-color: #383838; /* Used in the default.html file */
+}
+
 #openButton,
 #helpMessage {
   -fx-text-fill: white;

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,17 +1,17 @@
-#copyButton,
+#openButton,
 #helpMessage {
   -fx-text-fill: white;
 }
 
-#copyButton {
+#openButton {
   -fx-background-color: dimgray;
 }
 
-#copyButton:hover {
+#openButton:hover {
   -fx-background-color: gray;
 }
 
-#copyButton:armed {
+#openButton:armed {
   -fx-background-color: darkgray;
 }
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -49,13 +49,13 @@
 
         <ScrollPane fitToWidth="true">
           <VBox styleClass="commands-panel">
-            <Label styleClass="label-header" text="Basic Functions"/>
+            <Label styleClass="help-label" text="Basic Functions"/>
             <TableView fx:id="basicTableView">
               <VBox.margin>
                 <Insets top="10.0"/>
               </VBox.margin>
             </TableView>
-            <Label styleClass="label-header" text="Advanced Functions"/>
+            <Label styleClass="help-label" text="Advanced Functions"/>
             <TableView fx:id="advancedTableView">
               <VBox.margin>
                 <Insets top="10.0"/>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minWidth="450" minHeight="300" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minWidth="500" minHeight="300" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -23,7 +23,26 @@
         <URL value="@HelpWindow.css" />
       </stylesheets>
 
-      <VBox prefWidth="600" VBox.vgrow="NEVER" fx:id="helpContainer">
+      <VBox prefWidth="650" VBox.vgrow="NEVER" fx:id="helpContainer">
+
+        <ScrollPane fitToWidth="true">
+          <VBox styleClass="commands-panel">
+            <Label styleClass="help-label" text="Basic Functions"/>
+            <TableView fx:id="basicTableView">
+              <VBox.margin>
+                <Insets top="10.0"/>
+              </VBox.margin>
+            </TableView>
+            <!--Not implemented yet
+            <Label styleClass="help-label" text="Advanced Functions"/>
+            <TableView fx:id="advancedTableView">
+              <VBox.margin>
+                <Insets top="10.0"/>
+              </VBox.margin>
+            </TableView>
+            -->
+          </VBox>
+        </ScrollPane>
 
         <!--Container for User Guide reference and button-->
         <HBox alignment="CENTER">
@@ -46,23 +65,6 @@
             <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
           </padding>
         </HBox>
-
-        <ScrollPane fitToWidth="true">
-          <VBox styleClass="commands-panel">
-            <Label styleClass="help-label" text="Basic Functions"/>
-            <TableView fx:id="basicTableView">
-              <VBox.margin>
-                <Insets top="10.0"/>
-              </VBox.margin>
-            </TableView>
-            <Label styleClass="help-label" text="Advanced Functions"/>
-            <TableView fx:id="advancedTableView">
-              <VBox.margin>
-                <Insets top="10.0"/>
-              </VBox.margin>
-            </TableView>
-          </VBox>
-        </ScrollPane>
 
       </VBox>
     </Scene>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -7,38 +7,42 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minWidth="450" minHeight="300" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
   <scene>
     <Scene>
       <stylesheets>
+        <URL value="@DarkTheme.css" />
         <URL value="@HelpWindow.css" />
       </stylesheets>
 
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
-        <children>
-          <Label fx:id="helpMessage" text="Label">
-            <HBox.margin>
-              <Insets right="5.0" />
-            </HBox.margin>
-          </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-            <HBox.margin>
-              <Insets left="5.0" />
-            </HBox.margin>
-          </Button>
-        </children>
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
-        <padding>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </padding>
-      </HBox>
+      <VBox prefWidth="600" VBox.vgrow="NEVER" fx:id="helpContainer">
+        <HBox alignment="CENTER">
+          <children>
+            <Label fx:id="helpMessage" text="Label">
+              <HBox.margin>
+                <Insets right="5.0" />
+              </HBox.margin>
+            </Label>
+            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
+              <HBox.margin>
+                <Insets left="5.0" />
+              </HBox.margin>
+            </Button>
+          </children>
+          <opaqueInsets>
+            <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+          </opaqueInsets>
+          <padding>
+            <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+          </padding>
+        </HBox>
+      </VBox>
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -25,7 +25,7 @@
 
       <VBox prefWidth="650" VBox.vgrow="NEVER" fx:id="helpContainer">
 
-        <ScrollPane fitToWidth="true">
+        <ScrollPane fitToWidth="true" fitToHeight="true" VBox.vgrow="ALWAYS">
           <VBox styleClass="commands-panel">
             <Label styleClass="help-label" text="Basic Functions"/>
             <TableView fx:id="basicTableView">

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -5,6 +5,8 @@
 <?import javafx.scene.Scene?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TableView?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
@@ -22,6 +24,8 @@
       </stylesheets>
 
       <VBox prefWidth="600" VBox.vgrow="NEVER" fx:id="helpContainer">
+
+        <!--Container for User Guide reference and button-->
         <HBox alignment="CENTER">
           <children>
             <Label fx:id="helpMessage" text="Label">
@@ -29,7 +33,7 @@
                 <Insets right="5.0" />
               </HBox.margin>
             </Label>
-            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#openWebsite" text="User Guide">
+            <Button fx:id="openButton" mnemonicParsing="false" onAction="#openWebsite" text="User Guide">
               <HBox.margin>
                 <Insets left="5.0" />
               </HBox.margin>
@@ -42,6 +46,24 @@
             <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
           </padding>
         </HBox>
+
+        <ScrollPane fitToWidth="true">
+          <VBox styleClass="commands-panel">
+            <Label styleClass="label-header" text="Basic Functions"/>
+            <TableView fx:id="basicTableView">
+              <VBox.margin>
+                <Insets top="10.0"/>
+              </VBox.margin>
+            </TableView>
+            <Label styleClass="label-header" text="Advanced Functions"/>
+            <TableView fx:id="advancedTableView">
+              <VBox.margin>
+                <Insets top="10.0"/>
+              </VBox.margin>
+            </TableView>
+          </VBox>
+        </ScrollPane>
+
       </VBox>
     </Scene>
   </scene>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -29,7 +29,7 @@
                 <Insets right="5.0" />
               </HBox.margin>
             </Label>
-            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
+            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#openWebsite" text="User Guide">
               <HBox.margin>
                 <Insets left="5.0" />
               </HBox.margin>


### PR DESCRIPTION
**Resolves #80** 

Edited the `help` command. 
- It still opens a window, but now that window shows a summary of the app functions, and how to use them
- The summary of the app functions has only the command name, a one-line descriptor, and the command format (rows are highlighted on hovering)
- A reference to the User Guide is still there (now at the bottom), but now the button opens the URL in default browser instead of copying the URL to clipboard

![image](https://user-images.githubusercontent.com/78629832/195297571-ec246e64-ffdb-402d-b05a-074a764dd74b.png)

Future developments:
1. Commands should be updated appropriately. 
    - Notably, I'm currently dividing the functions into two categories, basic functions (such as `add`, `list`, `view`), and advanced functions (such as batch adding, performance tracking, etc. that we will implement later on)
    - Currently have commented out the advanced functions UI region (whoops bad habit)
    - If there are better ways to categorise them, please bring them up

3. Most likely, for coherence of the app, we can integrate the `helpWindow` into a `helpPanel` such that it can be displayed in the split panel that is going to be added in #77. Thus, it won't create another window (which is slightly annoying).

4. Aesthetics:
    - Fonts are a bit wonky (*not sure how to edit them*)
    - Spacing is very wonky (*kinda hard coded*)
    - Entire container can be selected, which gives it a nice blue border (*I hate blue*)
    - Looks ugly (@ngshijun *help please*)

