### PR TITLE
Fix bug for edit person command

### DIFF
--- a/src/main/java/coydir/logic/commands/EditCommand.java
+++ b/src/main/java/coydir/logic/commands/EditCommand.java
@@ -112,11 +112,13 @@ public class EditCommand extends Command {
         int updatedLeaves = editPersonDescriptor.getLeaves().orElse(currentLeaves);
         EmployeeId employeeId = personToEdit.getEmployeeId();
         Rating rating = personToEdit.getRating();
-
+        int currentLeavesLeft = personToEdit.getLeavesLeft();
         Person p = new Person(
                 updatedName, employeeId, updatedPhone, updatedEmail, updatedPosition,
                 updatedDepartment, updatedAddress, updatedTags, updatedLeaves, rating);
-        p.setLeavesLeft(updatedLeaves - currentLeaves + currentLeaves);
+        p.setLeavesLeft(updatedLeaves - currentLeaves + currentLeavesLeft);
+        p.setLeaves(personToEdit.getLeaves());
+        p.setRatingHistory(personToEdit.getRatingHistory());
         return p;
     }
 

--- a/src/main/java/coydir/model/person/Person.java
+++ b/src/main/java/coydir/model/person/Person.java
@@ -31,7 +31,7 @@ public class Person {
     private final Department department;
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
-    private final Queue<Leave> leaves = new PriorityQueue<>(Leave.COMPARATOR);
+    private Queue<Leave> leaves = new PriorityQueue<>(Leave.COMPARATOR);
     private final int totalNumberOfLeaves;
     private int leavesLeft = 0;
     private ArrayList<Rating> performanceHistory = new ArrayList<>();
@@ -134,6 +134,14 @@ public class Person {
 
     public ArrayList<Rating> getRatingHistory() {
         return this.performanceHistory;
+    }
+
+    public void setRatingHistory(ArrayList<Rating> ratinglist) {
+        this.performanceHistory = ratinglist;
+    }
+
+    public void setLeaves(Queue<Leave> leaves) {
+        this.leaves = leaves;
     }
 
     /**


### PR DESCRIPTION
Resolves #129 

Edit command now copies over the previous rating of the employee, and also the previous leave periods and leaves left. 