### PR TITLE
Refactor person fields

### DIFF
--- a/src/main/java/coydir/commons/core/Messages.java
+++ b/src/main/java/coydir/commons/core/Messages.java
@@ -4,12 +4,10 @@ package coydir.commons.core;
  * Container for user visible messages.
  */
 public class Messages {
-
     public static final String MESSAGE_UNKNOWN_COMMAND = " is an unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee ID provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INSUFFICIENT_LEAVES = "The employee does not have enough leaves!";
-
     public static final String MESSAGE_UNKNOWN_DEPARTMENT = " is not a valid department!";
 }

--- a/src/main/java/coydir/commons/core/Messages.java
+++ b/src/main/java/coydir/commons/core/Messages.java
@@ -7,7 +7,4 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = " is an unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee ID provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INSUFFICIENT_LEAVES = "The employee does not have enough leaves!";
-    public static final String MESSAGE_UNKNOWN_DEPARTMENT = " is not a valid department!";
 }

--- a/src/main/java/coydir/commons/exceptions/DataConversionException.java
+++ b/src/main/java/coydir/commons/exceptions/DataConversionException.java
@@ -7,5 +7,4 @@ public class DataConversionException extends Exception {
     public DataConversionException(Exception cause) {
         super(cause);
     }
-
 }

--- a/src/main/java/coydir/commons/util/ConfigUtil.java
+++ b/src/main/java/coydir/commons/util/ConfigUtil.java
@@ -19,5 +19,4 @@ public class ConfigUtil {
     public static void saveConfig(Config config, Path configFilePath) throws IOException {
         JsonUtil.saveJsonFile(config, configFilePath);
     }
-
 }

--- a/src/main/java/coydir/logic/commands/AddCommand.java
+++ b/src/main/java/coydir/logic/commands/AddCommand.java
@@ -62,7 +62,6 @@ public class AddCommand extends Command {
         requireNonNull(model);
         int currId = EmployeeId.getCount();
 
-
         if (model.hasPerson(toAdd)) {
             EmployeeId.setCount(--currId);
             throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON, toAdd.getName()));

--- a/src/main/java/coydir/logic/commands/AddLeaveCommand.java
+++ b/src/main/java/coydir/logic/commands/AddLeaveCommand.java
@@ -20,7 +20,7 @@ import coydir.model.person.Person;
  */
 public class AddLeaveCommand extends Command {
 
-    public static final String COMMAND_WORD = "addleave";
+    public static final String COMMAND_WORD = "add-leave";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds a leave period to an employee.\n"
             + "Parameters: "

--- a/src/main/java/coydir/logic/commands/BatchAddCommand.java
+++ b/src/main/java/coydir/logic/commands/BatchAddCommand.java
@@ -24,6 +24,7 @@ import coydir.model.person.Person;
  * Adds multiple person to the database
  */
 public class BatchAddCommand extends Command {
+
     public static final String COMMAND_WORD = "batch-add";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds multiple people into the database from a csv file \n"

--- a/src/main/java/coydir/logic/commands/BatchAddCommand.java
+++ b/src/main/java/coydir/logic/commands/BatchAddCommand.java
@@ -24,7 +24,7 @@ import coydir.model.person.Person;
  * Adds multiple person to the database
  */
 public class BatchAddCommand extends Command {
-    public static final String COMMAND_WORD = "batchadd";
+    public static final String COMMAND_WORD = "batch-add";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds multiple people into the database from a csv file \n"
             + "Parameters: filename (must be in the data folder of the repository and CSV format)\n"

--- a/src/main/java/coydir/logic/commands/ClearCommand.java
+++ b/src/main/java/coydir/logic/commands/ClearCommand.java
@@ -13,7 +13,6 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Database has been cleared!";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);

--- a/src/main/java/coydir/logic/commands/CommandResult.java
+++ b/src/main/java/coydir/logic/commands/CommandResult.java
@@ -53,6 +53,7 @@ public class CommandResult {
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
+     * Used only for the {@code View Department} command.
      */
     public CommandResult(String feedbackToUser, String department) {
         this.feedbackToUser = requireNonNull(feedbackToUser);

--- a/src/main/java/coydir/logic/commands/DeleteCommand.java
+++ b/src/main/java/coydir/logic/commands/DeleteCommand.java
@@ -40,7 +40,7 @@ public class DeleteCommand extends Command {
             if (person.getEmployeeId().equals(targetId)) {
                 model.deletePerson(person);
                 personToDelete = person;
-                return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete), false, false);
+                return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
             }
         }
         throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/coydir/logic/commands/DeleteLeaveCommand.java
+++ b/src/main/java/coydir/logic/commands/DeleteLeaveCommand.java
@@ -54,26 +54,30 @@ public class DeleteLeaveCommand extends Command {
         if (index < 0) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
+        Person targetPerson = null;
         for (Person person : lastShownList) {
             if (person.getEmployeeId().equals(targetId)) {
-                if (index > person.getLeaves().size()) {
-                    throw new CommandException(MESSAGE_INVALID_INDEX);
-                }
-                Leave removedLeave = null;
-                Queue<Leave> oldLeaves = person.getLeaves();
-                Queue<Leave> newLeaves = new PriorityQueue<>(oldLeaves);
-                int counter = 1;
-                while (counter++ < index) {
-                    newLeaves.remove();
-                }
-                removedLeave = newLeaves.remove();
-                oldLeaves.remove(removedLeave);
-                person.setLeavesLeft(person.getLeavesLeft() + removedLeave.getTotalDays());
-                return new CommandResult(String.format(
-                    MESSAGE_LEAVE_REMOVE_SUCCESS, person.getName()));
+                targetPerson = person;
+                break;
             }
         }
-        throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (targetPerson == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Queue<Leave> oldLeaves = targetPerson.getLeaves();
+        if (index > oldLeaves.size()) {
+            throw new CommandException(MESSAGE_INVALID_INDEX);
+        }
+        Queue<Leave> newLeaves = new PriorityQueue<>(oldLeaves);
+        int counter = 1;
+        while (counter++ < index) {
+            newLeaves.remove();
+        }
+        Leave removedLeave = newLeaves.remove();
+        oldLeaves.remove(removedLeave);
+        targetPerson.setLeavesLeft(targetPerson.getLeavesLeft() + removedLeave.getTotalDays());
+        return new CommandResult(String.format(MESSAGE_LEAVE_REMOVE_SUCCESS, targetPerson.getName()));
     }
 
     @Override

--- a/src/main/java/coydir/logic/commands/DeleteLeaveCommand.java
+++ b/src/main/java/coydir/logic/commands/DeleteLeaveCommand.java
@@ -20,7 +20,7 @@ import coydir.model.person.Person;
  */
 public class DeleteLeaveCommand extends Command {
 
-    public static final String COMMAND_WORD = "deleteleave";
+    public static final String COMMAND_WORD = "delete-leave";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes a leave period for an employee.\n"

--- a/src/main/java/coydir/logic/commands/FindCommand.java
+++ b/src/main/java/coydir/logic/commands/FindCommand.java
@@ -5,7 +5,6 @@ import static coydir.logic.parser.CliSyntax.PREFIX_NAME;
 import static coydir.logic.parser.CliSyntax.PREFIX_POSITION;
 import static java.util.Objects.requireNonNull;
 
-import coydir.commons.core.Messages;
 import coydir.model.Model;
 import coydir.model.person.PersonMatchesKeywordsPredicate;
 
@@ -29,6 +28,8 @@ public class FindCommand extends Command {
             + PREFIX_POSITION + "Recruiter "
             + PREFIX_DEPARTMENT + "Human Resources";
 
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+
     private final PersonMatchesKeywordsPredicate predicate;
 
     public FindCommand(PersonMatchesKeywordsPredicate predicate) {
@@ -40,7 +41,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/coydir/logic/commands/HelpCommand.java
+++ b/src/main/java/coydir/logic/commands/HelpCommand.java
@@ -12,10 +12,11 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window";
 
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
+
 }

--- a/src/main/java/coydir/logic/commands/ListCommand.java
+++ b/src/main/java/coydir/logic/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all employees";
 
 
     @Override

--- a/src/main/java/coydir/logic/commands/RateCommand.java
+++ b/src/main/java/coydir/logic/commands/RateCommand.java
@@ -17,6 +17,7 @@ import coydir.model.person.Rating;
  * Rate an employee's current performance.
  */
 public class RateCommand extends Command {
+
     public static final String COMMAND_WORD = "rate";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Rate the current performance of an employee.\n"
@@ -47,14 +48,20 @@ public class RateCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        Person targetPerson = null;
         for (Person person : lastShownList) {
             if (person.getEmployeeId().equals(targetId)) {
-                person.setRating(rating);
-                person.addRating(rating);
-                return new CommandResult(String.format(MESSAGE_RATE_SUCCESS, person.getName()));
+                targetPerson = person;
+                break;
             }
         }
-        throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (targetPerson == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        targetPerson.setRating(rating);
+        targetPerson.addRating(rating);
+        return new CommandResult(String.format(MESSAGE_RATE_SUCCESS, targetPerson.getName()));
     }
 
     @Override
@@ -64,4 +71,5 @@ public class RateCommand extends Command {
                 && targetId.equals(((RateCommand) other).targetId)
                 && rating.equals(((RateCommand) other).rating)); // state check
     }
+
 }

--- a/src/main/java/coydir/logic/commands/ViewCommand.java
+++ b/src/main/java/coydir/logic/commands/ViewCommand.java
@@ -11,9 +11,10 @@ import coydir.model.Model;
 import coydir.model.person.Person;
 
 /**
- * view a person's particular identified using it's displayed index from the database.
+ * View a person's particulars identified using their displayed index from the database.
  */
 public class ViewCommand extends Command {
+
     public static final String COMMAND_WORD = "view";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -42,4 +43,12 @@ public class ViewCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewCommand // instanceof handles nulls
+                && index.equals(((ViewCommand) other).index));
+    }
+
 }

--- a/src/main/java/coydir/logic/commands/ViewDepartmentCommand.java
+++ b/src/main/java/coydir/logic/commands/ViewDepartmentCommand.java
@@ -11,7 +11,7 @@ import coydir.model.person.Department;
  * view a person's particular identified using its displayed index from the database.
  */
 public class ViewDepartmentCommand extends Command {
-    public static final String COMMAND_WORD = "viewdepartment";
+    public static final String COMMAND_WORD = "view-department";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": View the department information in the displayed person list.\n"

--- a/src/main/java/coydir/logic/commands/ViewDepartmentCommand.java
+++ b/src/main/java/coydir/logic/commands/ViewDepartmentCommand.java
@@ -2,15 +2,15 @@ package coydir.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import coydir.commons.core.Messages;
 import coydir.logic.commands.exceptions.CommandException;
 import coydir.model.Model;
 import coydir.model.person.Department;
 
 /**
- * view a person's particular identified using its displayed index from the database.
+ * View a declared Department along with relevant information.
  */
 public class ViewDepartmentCommand extends Command {
+
     public static final String COMMAND_WORD = "view-department";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -19,20 +19,29 @@ public class ViewDepartmentCommand extends Command {
             + "Example: " + COMMAND_WORD + " Finance";
 
     public static final String MESSAGE_VIEW_DEPARTMENT_SUCCESS = "Viewing Department's info: %1$s";
+    public static final String MESSAGE_UNKNOWN_DEPARTMENT = " is not a valid department!";
 
-    private final String d;
+    private final String department;
 
-    public ViewDepartmentCommand(String d) {
-        this.d = d;
+    public ViewDepartmentCommand(String department) {
+        this.department = department;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (Department.isValidDepartment(d)) {
-            return new CommandResult(String.format(MESSAGE_VIEW_DEPARTMENT_SUCCESS, d), d);
+        if (Department.isValidDepartment(department)) {
+            return new CommandResult(String.format(MESSAGE_VIEW_DEPARTMENT_SUCCESS, department), department);
         } else {
-            throw new CommandException(Messages.MESSAGE_UNKNOWN_DEPARTMENT);
+            throw new CommandException(MESSAGE_UNKNOWN_DEPARTMENT);
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewDepartmentCommand // instanceof handles nulls
+                && department.equals(((ViewDepartmentCommand) other).department));
+    }
+
 }

--- a/src/main/java/coydir/logic/parser/AddCommandParser.java
+++ b/src/main/java/coydir/logic/parser/AddCommandParser.java
@@ -54,9 +54,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         EmployeeId employeeId = new EmployeeId();
 
         // Set optional fields as default/null values
-        Phone phone = new Phone().getNullPhone();
-        Email email = new Email().getNullEmail();
-        Address address = new Address().getNullAddress();
+        Phone phone = Phone.getNullPhone();
+        Email email = Email.getNullEmail();
+        Address address = Address.getNullAddress();
         Set<Tag> tagList = new HashSet<>();
 
         Rating rating = new Rating().getNullRating();

--- a/src/main/java/coydir/logic/parser/AddCommandParser.java
+++ b/src/main/java/coydir/logic/parser/AddCommandParser.java
@@ -57,10 +57,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = Phone.getNullPhone();
         Email email = Email.getNullEmail();
         Address address = Address.getNullAddress();
+        Rating rating = Rating.getNullRating();
         Set<Tag> tagList = new HashSet<>();
-
-        Rating rating = new Rating().getNullRating();
-
         int numberOfLeaves = DEFAULT_LEAVES;
 
         // Set optional fields individually

--- a/src/main/java/coydir/logic/parser/AddCommandParser.java
+++ b/src/main/java/coydir/logic/parser/AddCommandParser.java
@@ -73,14 +73,13 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         }
-
         if (!argMultimap.getAllValues(PREFIX_TAG).isEmpty()) {
             tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         }
-
         if (!argMultimap.getAllValues(PREFIX_LEAVE).isEmpty()) {
             numberOfLeaves = Integer.valueOf(ParserUtil.parseId(argMultimap.getValue(PREFIX_LEAVE).get()));
         }
+
         Person person = new Person(
                 name, employeeId, phone, email, position, department, address, tagList, numberOfLeaves, rating
                 );
@@ -95,5 +94,4 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/coydir/logic/parser/AddLeaveCommandParser.java
+++ b/src/main/java/coydir/logic/parser/AddLeaveCommandParser.java
@@ -30,7 +30,7 @@ public class AddLeaveCommandParser implements Parser<AddLeaveCommand> {
         }
         String id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
         Leave leave = ParserUtil.parseLeave(
-            argMultimap.getValue(PREFIX_STARTDATE).get(), argMultimap.getValue(PREFIX_ENDDATE).get());
+                argMultimap.getValue(PREFIX_STARTDATE).get(), argMultimap.getValue(PREFIX_ENDDATE).get());
         return new AddLeaveCommand(new EmployeeId(id), leave);
     }
 
@@ -41,4 +41,5 @@ public class AddLeaveCommandParser implements Parser<AddLeaveCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
+
 }

--- a/src/main/java/coydir/logic/parser/RateCommandParser.java
+++ b/src/main/java/coydir/logic/parser/RateCommandParser.java
@@ -28,8 +28,7 @@ public class RateCommandParser implements Parser<RateCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RateCommand.MESSAGE_USAGE));
         }
         String id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-        Rating rating = ParserUtil.parseRating(
-            argMultimap.getValue(PREFIX_RATE).get());
+        Rating rating = ParserUtil.parseRating(argMultimap.getValue(PREFIX_RATE).get());
         return new RateCommand(new EmployeeId(id), rating);
     }
 
@@ -40,4 +39,5 @@ public class RateCommandParser implements Parser<RateCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
+
 }

--- a/src/main/java/coydir/model/person/Address.java
+++ b/src/main/java/coydir/model/person/Address.java
@@ -39,7 +39,7 @@ public class Address {
         this.value = "N/A";
     }
 
-    public Address getNullAddress() {
+    public static Address getNullAddress() {
         return Address.NULL;
     }
 

--- a/src/main/java/coydir/model/person/Email.java
+++ b/src/main/java/coydir/model/person/Email.java
@@ -52,7 +52,7 @@ public class Email {
         this.value = "N/A";
     }
 
-    public Email getNullEmail() {
+    public static Email getNullEmail() {
         return Email.NULL;
     }
 

--- a/src/main/java/coydir/model/person/Leave.java
+++ b/src/main/java/coydir/model/person/Leave.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javafx.beans.property.SimpleStringProperty;
@@ -139,5 +140,10 @@ public class Leave {
     @Override
     public String toString() {
         return String.format("%s - %s", startDate, endDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startDate, endDate);
     }
 }

--- a/src/main/java/coydir/model/person/Phone.java
+++ b/src/main/java/coydir/model/person/Phone.java
@@ -33,7 +33,7 @@ public class Phone {
         this.value = "N/A";
     }
 
-    public Phone getNullPhone() {
+    public static Phone getNullPhone() {
         return Phone.NULL;
     }
 

--- a/src/main/java/coydir/model/person/Rating.java
+++ b/src/main/java/coydir/model/person/Rating.java
@@ -61,7 +61,7 @@ public class Rating {
         this.timestamp = LocalDate.now();
     }
 
-    public Rating getNullRating() {
+    public static Rating getNullRating() {
         return Rating.NULL;
     }
 

--- a/src/main/java/coydir/storage/JsonAdaptedPerson.java
+++ b/src/main/java/coydir/storage/JsonAdaptedPerson.java
@@ -28,6 +28,7 @@ import coydir.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String LEAVES_FIELD = "Number of Leaves";
 
     private final String name;
     private final String employeeId;
@@ -193,10 +194,18 @@ class JsonAdaptedPerson {
             modelAddress = new Address(address);
         }
 
-        if (leave == null) {
-            throw new IllegalValueException("Invalid");
+        final int modelLeave;
+        final int leaveLeftTransfer;
+        if (leave == null || leaveLeft == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, LEAVES_FIELD));
+        } else {
+            try {
+                modelLeave = Integer.valueOf(leave);
+                leaveLeftTransfer = Integer.valueOf(leaveLeft);
+            } catch (NumberFormatException nfe) {
+                throw new IllegalValueException(String.format("%s is not a valid integer", leave));
+            }
         }
-        final int modelLeave = Integer.valueOf(leave);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
@@ -218,7 +227,7 @@ class JsonAdaptedPerson {
                 modelRating);
 
         // Add related data
-        p.setLeavesLeft(Integer.valueOf(leaveLeft));
+        p.setLeavesLeft(leaveLeftTransfer);
         for (Leave l : personLeaves) {
             p.addLeave(l);
         }

--- a/src/main/java/coydir/storage/JsonAdaptedPerson.java
+++ b/src/main/java/coydir/storage/JsonAdaptedPerson.java
@@ -196,11 +196,9 @@ class JsonAdaptedPerson {
         if (leave == null) {
             throw new IllegalValueException("Invalid");
         }
-
         final int modelLeave = Integer.valueOf(leave);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        final Set<Leave> modelLeaveTaken = new HashSet<>(personLeaves);
 
         final Rating modelRating;
         if (rating == null) {
@@ -214,8 +212,6 @@ class JsonAdaptedPerson {
             modelRating = new Rating(rating);
         }
 
-        final ArrayList<Rating> modelPerformanceHistory = new ArrayList<>(personRatings);
-
         // Create Person object
         Person p = new Person(modelName, modelEmployeeId, modelPhone, modelEmail,
                 modelPosition, modelDepartment, modelAddress, modelTags, modelLeave,
@@ -223,11 +219,11 @@ class JsonAdaptedPerson {
 
         // Add related data
         p.setLeavesLeft(Integer.valueOf(leaveLeft));
-        for (Leave l : modelLeaveTaken) {
+        for (Leave l : personLeaves) {
             p.addLeave(l);
         }
 
-        for (Rating r : modelPerformanceHistory) {
+        for (Rating r : personRatings) {
             p.addRating(r);
         }
 

--- a/src/main/java/coydir/storage/JsonAdaptedRating.java
+++ b/src/main/java/coydir/storage/JsonAdaptedRating.java
@@ -13,6 +13,7 @@ import coydir.model.tag.Tag;
  * Jackson-friendly version of {@link Rating}.
  */
 public class JsonAdaptedRating {
+
     private final String value;
     private final String timestamp;
 
@@ -44,4 +45,5 @@ public class JsonAdaptedRating {
         }
         return new Rating(value, timestamp);
     }
+
 }

--- a/src/main/java/coydir/ui/DepartmentInfo.java
+++ b/src/main/java/coydir/ui/DepartmentInfo.java
@@ -17,7 +17,7 @@ import javafx.scene.layout.VBox;
 
 
 /**
- * An UI component that displays detailed information of a {@code Person}.
+ * An UI component that displays detailed information of a {@code Department}.
  */
 public class DepartmentInfo extends UiPart<Region> {
     private static final String FXML = "DepartmentInfo.fxml";

--- a/src/main/java/coydir/ui/HomePanel.java
+++ b/src/main/java/coydir/ui/HomePanel.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
  * e.g. after deleting the employee currently displayed.
  */
 public class HomePanel extends UiPart<Region> {
+
     private static final String FXML = "HomePanel.fxml";
     private static final coydir.commons.core.Version VERSION = MainApp.VERSION;
     private static final String MESSAGE = String.format("\tWelcome To\t\n\tCoydir %s\t", VERSION.toString());
@@ -42,4 +43,5 @@ public class HomePanel extends UiPart<Region> {
         logo.setImage(logoImage);
         message.setText(MESSAGE);
     }
+
 }

--- a/src/main/java/coydir/ui/MainWindow.java
+++ b/src/main/java/coydir/ui/MainWindow.java
@@ -232,20 +232,19 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
-    private void handleViewPerson(int index) {
-        Person currentPerson = logic.getFilteredPersonList().get(index);
-        personInfo.update(currentPerson);
-        setSidePanel(personInfo);
-        currentIndex = index;
-    }
-
-    private void handleUpdate(int index) {
+    private void handlePersonInfoUpdate(int index) {
         ObservableList<Person> personList = logic.getFilteredPersonList();
         if (index >= personList.size()) {
             setSidePanel(homePanel);
         } else {
             personInfo.update(logic.getFilteredPersonList().get(index));
         }
+        currentIndex = index;
+    }
+
+    private void handleViewPerson(int index) {
+        handlePersonInfoUpdate(index);
+        setSidePanel(personInfo);
     }
 
     private void handleViewDepartmentUpdate(String department) {
@@ -254,8 +253,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private void handleViewDepartment(String department) {
         departmentInfo.update(logic.getUnfilteredPersonList(), department);
-        sidePanelPlaceholder.getChildren().clear();
-        sidePanelPlaceholder.getChildren().add(departmentInfo.getRoot());
+        setSidePanel(departmentInfo);
     }
 
     public PersonListPanel getPersonListPanel() {
@@ -272,7 +270,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            handleUpdate(currentIndex);
+            handlePersonInfoUpdate(currentIndex);
             handleViewDepartmentUpdate(currentDepartment);
 
             if (commandResult.isShowHelp()) {

--- a/src/main/java/coydir/ui/PersonCard.java
+++ b/src/main/java/coydir/ui/PersonCard.java
@@ -71,4 +71,5 @@ public class PersonCard extends UiPart<Region> {
         return id.getText().equals(card.id.getText())
                 && person.equals(card.person);
     }
+
 }

--- a/src/main/java/coydir/ui/PersonInfo.java
+++ b/src/main/java/coydir/ui/PersonInfo.java
@@ -129,7 +129,7 @@ public class PersonInfo extends UiPart<Region> {
         endDate.setSortable(false);
         endDate.setReorderable(false);
 
-        TableColumn<Leave, Integer> durations = new TableColumn<>("Durations");
+        TableColumn<Leave, Integer> durations = new TableColumn<>("Duration");
         durations.setCellValueFactory(new PropertyValueFactory<>("col3"));
         durations.setSortable(false);
         durations.setReorderable(false);

--- a/src/test/java/coydir/logic/commands/FindCommandTest.java
+++ b/src/test/java/coydir/logic/commands/FindCommandTest.java
@@ -1,6 +1,5 @@
 package coydir.logic.commands;
 
-import static coydir.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static coydir.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static coydir.testutil.TypicalPersons.CARL;
 import static coydir.testutil.TypicalPersons.DANIEL;
@@ -58,7 +57,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_oneKeyword_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        String expectedMessage = String.format(FindCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
         PersonMatchesKeywordsPredicate predicate = preparePredicate("el");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -68,7 +67,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_onePersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(FindCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         PersonMatchesKeywordsPredicate predicate = preparePredicate("Kurz Fire Operations");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -78,7 +77,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_mismatchedKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(FindCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         PersonMatchesKeywordsPredicate predicate = preparePredicate("Alice Fire");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);


### PR DESCRIPTION
This is a PR purely for minor changes that I had been planning on doing for a while.

- Made *NULL* values of optional `Person` fields accessible through static methods only
- Change of two word commands to include hyphens
    - `batchadd` to `batch-add`
    - `addleave` to `add-leave`
    - `deleteleave` to `delete-leave`
    - `viewdepartment` to `view-department`
- Cleanup of coding standards and code quality
- Fix mouse event bug leading to index out of bounds exception in log (terminal)
- Fix exception thrown sometimes when data file is tampered/corrupted

As mentioned, these are a bunch of random changes altogether, many of these not really discussed with you all yet (*whoops sorry*). Please take a look through and give feedback and suggestions.