### PR TITLE
Fix RateCommand getPersonList bug

### DIFF
--- a/src/main/java/coydir/logic/commands/RateCommand.java
+++ b/src/main/java/coydir/logic/commands/RateCommand.java
@@ -49,7 +49,7 @@ public class RateCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getDatabase().getPersonList();
         Person targetPerson = null;
         for (Person person : lastShownList) {
             if (person.getEmployeeId().equals(targetId)) {


### PR DESCRIPTION
Fix RateCommand getPersonList bug

Now:
- Users can rate any employee based on id, regardless of which employees are displayed after filtering with `find`